### PR TITLE
When USB manufacturer is unknown, use idVendor instead

### DIFF
--- a/dtails.py
+++ b/dtails.py
@@ -114,7 +114,11 @@ class MyApp(tk.Tk):
             devices = context.list_devices(subsystem='block', ID_BUS='usb')
             self.pendrives = {}
             for device in devices:
-                self.pendrives[device.get('ID_VENDOR')] = device.device_node[:-1]
+                if not device.get('ID_VENDOR'):
+                    print_yellow("No USB Manufacturer found on internal database... Using idVendor instead.")
+                    self.pendrives[device.get('ID_VENDOR_ID')] = device.device_node[:-1]
+                else:
+                    self.pendrives[device.get('ID_VENDOR')] = device.device_node[:-1]
             if self.pendrives:
                 #self.pendrive_var.set(list(self.pendrives)[0])
                 if self.pendrive_var.get() == "":


### PR DESCRIPTION
When connecting a Flash Drive that the host do not recognize the Manufacturer we use idVendor. That is probably because the internal **usb.ids** file is not up to date. 

To know the idVendor, type in your terminal: dmesg

* After connecting your flash drive and check the idVendor just to be sure.

If you want to check manually your Manufacturer by idVendor go to this website: https://usb-ids.gowdy.us/read/UD/

PR made to fix this issue: https://github.com/DesobedienteTecnologico/dtails/issues/9