### PR TITLE
Adding missing copy command for seedtool.html in installer.py

### DIFF
--- a/src/installer.py
+++ b/src/installer.py
@@ -82,6 +82,8 @@ def install_seedtool():
     subprocess.run("cp dotfiles/logos/seedtool.png shared_with_chroot/", shell=True)
     add_script_config("\ncp /tmp/seedtool.png /opt/logos/")
     add_script_config("\ncp /tmp/seedtool.desktop /usr/share/applications/")
+    add_script_config("\ncp /tmp/seedtool.html /etc/skel/Tor\ Browser/")
+
 
 def install_border_wallets():
     subprocess.run("cp dotfiles/dotdesktop/borderwallet.desktop shared_with_chroot/", shell=True)


### PR DESCRIPTION
Seedtool from application menu didn't work because there was the copy command was missing in installer.py